### PR TITLE
Rename "g4_pdg" dataset in particle table

### DIFF
--- a/numl/NeutrinoML/HDF5Maker_module.cc
+++ b/numl/NeutrinoML/HDF5Maker_module.cc
@@ -936,7 +936,7 @@ void HDF5Maker::createFile(const art::SubRun* sr) {
     make_ntuple({fFile, "particle_table", 1000},
       make_column<int>("event_id", 3),
       make_scalar_column<int>("g4_id"),
-      make_scalar_column<int>("g4_pdg"),
+      make_scalar_column<int>("type"),
       make_scalar_column<int>("parent_id"),
       make_scalar_column<int>("category"),
       make_scalar_column<int>("instance"),


### PR DESCRIPTION
in the uboone open data release, the "type" dataset in the particle table of the HDF5s was renamed to "g4_pdg", which breaks compatibility with downstream PyNuML processing. either the HDF5-maker art module or the python processing needs to be changed – i think for compatibility with previous data, reverting the dataset name in the event HDF5s is a simpler fix, although i'm open to arguments to the contrary.

submitting this PR now because the workflow currently requires manual intervention to rename this dataset in the event HDF5 file, and we just tripped up on this again while reprocessing. let me know your thoughts! if you approve this PR to your fork, then i can then PR it back into the main repo so everything is consistent. thanks!